### PR TITLE
feature: product of pomdp with predicates and parity automaton with priorities

### DIFF
--- a/pomdpy/pomdp.py
+++ b/pomdpy/pomdp.py
@@ -184,11 +184,22 @@ class POMDP:
         for i, s in enumerate(ids):
             self.obsinv[s] = i
 
-    def addPriority(self, priority, states):
+    def addPriority(self, priority, states, ids = False):
         if priority not in self.prio:
             self.prio[priority] = set()
         for state in states:
-            self.prio[priority].add(self.statesinv[state])
+            self.prio[priority].add(state if ids else self.statesinv[state])
+
+    def generateFormula(self, state):
+        # Important assumption: every predicate used in the LTL formula is true somewhere
+        terms = []
+        for prop in self.prio.keys():
+            if state in self.prio[prop]:
+                terms.append("p"+str(prop))
+            else:
+                terms.append("!p"+str(prop))
+
+        return ' & '.join(terms)
 
     def show(self, outfname):
         G = pgv.AGraph(directed=True, strict=False)

--- a/pomdpy/product.py
+++ b/pomdpy/product.py
@@ -1,0 +1,83 @@
+import spot
+from pomdpy.parsers import pomdp
+from pomdpy.pomdp import POMDP
+from itertools import product as setproduct
+
+# we may use spot.split_edges at some point
+
+
+def get_product_state_index(env, s, a):
+    return a * len(env.states) + s
+
+
+def get_next_state(env, aut, s, a):
+    bdict = aut.get_dict()
+    formula = env.generateFormula(s)
+    transitions = aut.out(a)
+    for t in transitions:
+        if formula == spot.bdd_format_formula(bdict, t.cond):
+            return t.dst
+    assert False
+
+
+def init_product(env, aut):
+    product = POMDP()
+    aut = spot.split_edges(aut)
+    product_states = [
+        f"{s}-{i}" for s, i in setproduct(env.states, range(aut.num_states()))
+    ]
+    product.setStates(len(product_states))
+    product.setActions(env.actions)
+    product.setObs(env.obs)
+    return product
+
+
+def get_state_name(product, env, aut, idx):
+    env_idx = idx // len(env.states)
+    aut_idx = idx % aut.num_states()
+    return f"{env.states[env_idx]}-{aut_idx}"
+
+
+def set_start_probs(product: POMDP, env: POMDP, aut):
+    for start_state in env.start:
+        a_ = get_next_state(env, aut, start_state, aut.get_init_state_number())
+        state = get_product_state_index(env, start_state, a_)
+        product.start[state] = env.start[start_state]
+
+
+def set_transition_probs(product: POMDP, env: POMDP, aut):
+    for a in range(aut.num_states()):
+        for src in env.trans:
+            src_product = get_product_state_index(env, src, a)
+            for act in env.trans[src]:
+                for dst in env.trans[src][act]:
+                    a_ = get_next_state(env, aut, dst, a)
+                    dst_product = get_product_state_index(env, dst, a_)
+                    p = env.trans[src][act][dst]
+                    product._addOneTrans(src_product, act, dst_product, p)
+
+
+def set_obs_probs(product: POMDP, env: POMDP, aut):
+    # action -> dst -> obs
+    for a in range(aut.num_states()):
+        for act in env.obsfun:
+            for dst in env.obsfun[act]:
+                for obs in env.obsfun[act][dst]:
+                    p = env.obsfun[act][dst][obs]
+                    product._addOneObs(
+                        act, get_product_state_index(env, dst, a), obs, p
+                    )
+
+
+def set_priorities(product: POMDP, env: POMDP, aut):
+    simplified_buchi = aut.acc().num_sets() == 1
+    for a in range(aut.num_states()):
+        for s in range(len(env.states)):
+            for prio in list(aut.state_acc_sets(a).sets()):
+                product.addPriority(
+                    prio + (2 if simplified_buchi else 0),
+                    [get_product_state_index(env, s, a)],
+                    ids=True,
+                )
+            if list(aut.state_acc_sets(a).sets()) == []:
+                product.addPriority(1, [get_product_state_index(env, s, a)], ids=True)

--- a/pomdpy/tests/test_product.py
+++ b/pomdpy/tests/test_product.py
@@ -1,0 +1,137 @@
+from pomdpy.beliefsuppaut import BeliefSuppAut
+from pomdpy.pomdp import POMDP
+from pomdpy.parsers import pomdp
+from pomdpy.product import (
+    init_product,
+    set_start_probs,
+    get_product_state_index,
+    get_next_state,
+    set_transition_probs,
+    set_priorities,
+    set_obs_probs
+)
+
+import spot
+
+
+def test_next_state():
+    env = POMDP()
+    env.setStates(["a", "b"])
+    env.prio[0] = set([0])
+    env.prio[1] = set([0, 1])
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+    assert get_next_state(env, aut, 0, 0) == 0
+
+    env.prio[1] = set([1])
+    assert get_next_state(env, aut, 0, 0) == 1
+
+    env.prio[0] = set()
+    assert get_next_state(env, aut, 0, 0) == 2
+
+
+def test_number_of_states():
+    env = POMDP()
+    env.setStates([str(i) for i in range(10)])
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+    assert aut.num_states() == 5
+
+    product = init_product(env, aut)
+    assert len(product.states) == len(env.states) * aut.num_states()
+
+
+def test_ititial_state():
+    env = POMDP()
+    env.setStates(["a", "b"])
+    env.start[env.statesinv["a"]] = 1.0
+    env.prio[0] = set([env.statesinv["a"]])
+
+    aut = spot.translate("FGp0", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+    product = init_product(env, aut)
+    set_start_probs(product, env, aut)
+    assert product.start[get_product_state_index(env, 0, 0)] == 1.0
+
+    ####
+
+    env = POMDP()
+    env.setStates(["a", "b"])
+    env.start[env.statesinv["a"]] = 0.25
+    env.start[env.statesinv["b"]] = 0.75
+    env.prio[0] = set([0, 1])
+    env.prio[1] = set([0])
+
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+    product = init_product(env, aut)
+    set_start_probs(product, env, aut)
+    assert product.start[get_product_state_index(env, 0, 0)] == 0.25
+    assert product.start[get_product_state_index(env, 1, 1)] == 0.75
+
+
+def test_transitions():
+    env = POMDP()
+    env.setStates(["a", "b"])
+    env.setActions(["act1"])
+    env._addOneTrans(0, 0, 0, 0.1)
+    env._addOneTrans(0, 0, 1, 0.9)
+    env._addOneTrans(1, 0, 1, 0.2)
+    env._addOneTrans(1, 0, 0, 0.8)
+
+    env.prio[0] = set([0, 1])
+    env.prio[1] = set([0])
+
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+
+    product = init_product(env, aut)
+    set_transition_probs(product, env, aut)
+    print(env.trans)
+    print(product.trans)
+    assert product.trans[0][0][0] == 0.1
+    assert product.trans[0][0][3] == 0.9
+    assert product.trans[9][0][0] == 0.8
+    assert product.trans[9][0][7] == 0.2
+
+
+def test_observations():
+    env = POMDP()
+    env.setStates(["a", "b"])
+    env.setActions(["act1"])
+    env.setObs(["obs1", "obs2"])
+    # obsfun: action -> dst -> obs
+    env._addOneObs(0, 0, 0, 0.6)  # act1, a, obs1
+    env._addOneObs(0, 0, 1, 0.4)  # act1, a, obs2
+    env._addOneObs(0, 1, 0, 0.7)  # act1, b, obs1
+    env._addOneObs(0, 1, 1, 0.3)  # act1, b, obs2
+
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+
+    product = init_product(env, aut)
+    set_obs_probs(product, env, aut)
+
+    for a in range(aut.num_states()):
+        idx_a = get_product_state_index(env, 0, a)
+        idx_b = get_product_state_index(env, 1, a)
+        # act1 = 0, obs1 = 0, obs2 = 1
+        assert product.obsfun[0][idx_a][0] == 0.6
+        assert product.obsfun[0][idx_a][1] == 0.4
+        assert product.obsfun[0][idx_b][0] == 0.7
+        assert product.obsfun[0][idx_b][1] == 0.3
+
+
+def test_priorities():
+    env = POMDP()
+    env.setStates(["a", "b"])
+
+    aut = spot.translate("GFp0 & GFp1", "parity", "SBAcc")
+    aut = spot.split_edges(aut)
+
+    product = init_product(env, aut)
+    set_priorities(product, env, aut)
+
+    assert product.prio[2] == set([0, 2, 1, 3])
+    assert product.prio[1] == set([4, 6, 8, 5, 7, 9])
+


### PR DESCRIPTION
The code adds the product construction for a pomdp and a spot-generated automaton.

For atomic propositions in the pomdp I use a somewhat hacky approach: already implemented priorities serve as containers for the propositions. Thus, a pomdp currently can have either priorities or propositions. 

This also implies that the LTL formula should have only propositions that are named p0, p1, etc. 

Moreover, the pomdp should have every proposition from the formula true at least somewhere.

There are also tests.